### PR TITLE
feat: rolled back bbox from static values to a dynamic map.getBound()

### DIFF
--- a/src/algorithms/supercluster.ts
+++ b/src/algorithms/supercluster.ts
@@ -92,8 +92,10 @@ export class SuperClusterAlgorithm extends AbstractAlgorithm {
   }
 
   public cluster({ map }: AlgorithmInput): Cluster[] {
+    const { west, south, east, north } = map.getBounds().toJSON();
+
     return this.superCluster
-      .getClusters([-180, -90, 180, 90], Math.round(map.getZoom()))
+      .getClusters([west, south, east, north], Math.round(map.getZoom()))
       .map(this.transformCluster.bind(this));
   }
 


### PR DESCRIPTION
Linked to issue : [#136](https://github.com/googlemaps/js-markerclusterer/issues/136)