### PR TITLE
Passing map bounding box to SuperCluster

### DIFF
--- a/src/algorithms/supercluster.test.ts
+++ b/src/algorithms/supercluster.test.ts
@@ -102,11 +102,19 @@ test("should not cluster if zoom didn't change", () => {
 
   const superCluster = new SuperClusterAlgorithm({});
   superCluster["markers"] = markers;
-  superCluster["state"] = { zoom: 12 };
+  superCluster["state"] = { zoom: 12, boundingBox: [-180, -90, 180, 90] };
   superCluster.cluster = jest.fn().mockReturnValue([]);
   superCluster["clusters"] = [];
 
   map.getZoom = jest.fn().mockReturnValue(superCluster["state"].zoom);
+  map.getBounds = jest.fn().mockReturnValue({
+    toJSON: () => ({
+      west: -180,
+      south: -90,
+      east: 180,
+      north: 90,
+    }),
+  });
 
   const { clusters, changed } = superCluster.calculate({
     markers,
@@ -128,7 +136,7 @@ test("should not cluster if zoom beyond maxZoom", () => {
 
   const superCluster = new SuperClusterAlgorithm({});
   superCluster["markers"] = markers;
-  superCluster["state"] = { zoom: 20 };
+  superCluster["state"] = { zoom: 20, boundingBox: [-180, -90, 180, 90] };
   superCluster.cluster = jest.fn().mockReturnValue([]);
   superCluster["clusters"] = [];
 

--- a/src/algorithms/supercluster.test.ts
+++ b/src/algorithms/supercluster.test.ts
@@ -152,6 +152,15 @@ test("should round fractional zoom", () => {
   const superCluster = new SuperClusterAlgorithm({});
   superCluster["superCluster"].getClusters = jest.fn().mockReturnValue([]);
 
+  map.getBounds = jest.fn().mockReturnValue({
+    toJSON: () => ({
+      west: -180,
+      south: -90,
+      east: 180,
+      north: 90,
+    }),
+  });
+
   map.getZoom = jest.fn().mockReturnValue(1.534);
   superCluster.cluster({ map, mapCanvasProjection, markers });
   expect(superCluster["superCluster"].getClusters).toHaveBeenCalledWith(

--- a/src/algorithms/supercluster.ts
+++ b/src/algorithms/supercluster.ts
@@ -95,8 +95,13 @@ export class SuperClusterAlgorithm extends AbstractAlgorithm {
 
   public cluster({ map }: AlgorithmInput): Cluster[] {
     return this.superCluster
-      .getClusters([-180, -90, 180, 90], Math.round(map.getZoom()))
+      .getClusters(this.getBoundingBox(map), Math.round(map.getZoom()))
       .map(this.transformCluster.bind(this));
+  }
+
+  protected getBoundingBox(map: google.maps.Map): [number, number, number, number] {
+    const bounds = map.getBounds().toJSON();
+    return [bounds.west, bounds.south, bounds.east, bounds.north];
   }
 
   protected transformCluster({


### PR DESCRIPTION
The SuperCluster algorithm is receiving a static bounding box of `[-180, -90, 180, 90]`. This is causing performance issues when dealing with larger marker counts or when you are zoomed in with relatively low marker counts (1000). This is because it is trying to render thousands of markers that aren't visible on the screen.

By passing in the map's bounding box, performance increases considerably. During testing I was able to go from struggling with 1000 markers, to no issues at all with 5000.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #417 🦕
