### PR TITLE
fix: fixed marker flickering caused by creating new instances on each render

### DIFF
--- a/src/markerclusterer.test.ts
+++ b/src/markerclusterer.test.ts
@@ -248,20 +248,20 @@ describe.each(markerClasses)(
     test("markerClusterer does not recreate marker when unaffected", () => {
       const unaffectedMarkerPosition = {
         lat: 0,
-        lng: 0
+        lng: 0,
       };
-      
+
       const unaffectedMarker = new markerClass({
-        position: unaffectedMarkerPosition
+        position: unaffectedMarkerPosition,
       });
-      
+
       const newMarkerPosition = {
         lat: 10,
-        lng: 10
+        lng: 10,
       };
 
       const newMarker = new markerClass({
-        position: newMarkerPosition
+        position: newMarkerPosition,
       });
 
       map.setCenter({ lat: 0, lng: 0 });
@@ -269,22 +269,27 @@ describe.each(markerClasses)(
 
       const markerClusterer = new MarkerClusterer({
         renderer,
-        algorithm
+        algorithm,
       });
 
       MarkerUtils.setMap = jest.fn();
       markerClusterer.getMap = jest.fn().mockImplementation(() => map);
-      markerClusterer.getProjection = jest.fn().mockImplementation(() => map.getProjection());
+      markerClusterer.getProjection = jest
+        .fn()
+        .mockImplementation(() => map.getProjection());
 
       markerClusterer.addMarker(unaffectedMarker);
-      
+
       jest.spyOn(algorithm, "calculate").mockImplementationOnce(() => {
         return {
           changed: true,
           clusters: [
-            new Cluster({ markers: [ markerClusterer["markers"][0] ], position: unaffectedMarkerPosition })
-          ]
-        }
+            new Cluster({
+              markers: [markerClusterer["markers"][0]],
+              position: unaffectedMarkerPosition,
+            }),
+          ],
+        };
       });
 
       markerClusterer.addMarker(newMarker);
@@ -293,15 +298,21 @@ describe.each(markerClasses)(
         return {
           changed: true,
           clusters: [
-            new Cluster({ markers: [ markerClusterer["markers"][0] ], position: unaffectedMarkerPosition }),
-            new Cluster({ markers: [ markerClusterer["markers"][1] ], position: newMarkerPosition })
-          ]
-        }
+            new Cluster({
+              markers: [markerClusterer["markers"][0]],
+              position: unaffectedMarkerPosition,
+            }),
+            new Cluster({
+              markers: [markerClusterer["markers"][1]],
+              position: newMarkerPosition,
+            }),
+          ],
+        };
       });
 
       jest.spyOn(MarkerUtils, "setMap").mockClear();
       jest.spyOn(MarkerUtils, "getPosition").mockClear();
-      
+
       markerClusterer.render();
 
       expect(markerClusterer["markers"]).toHaveLength(2);

--- a/src/markerclusterer.test.ts
+++ b/src/markerclusterer.test.ts
@@ -211,7 +211,6 @@ test("markerClusterer onRemove calls reset and removes listener", () => {
 
   markerClusterer.onRemove();
 
-  expect(markerClusterer["reset"]).toBeCalledTimes(1);
   expect(markerClusterer["idleListener"]).toBeUndefined();
 });
 

--- a/src/markerclusterer.test.ts
+++ b/src/markerclusterer.test.ts
@@ -245,6 +245,32 @@ describe.each(markerClasses)(
       expect(markerClusterer["markers"]).toHaveLength(1);
     });
 
+    test("markerClusterer does not recreate marker when unaffected", () => {
+      const markerClusterer = new MarkerClusterer({
+        markers: [],
+      });
+
+      const unaffectedMarker = new markerClass({
+        position: {
+          lat: 0,
+          lng: 0
+        }
+      });
+
+      markerClusterer.addMarker(unaffectedMarker, false);
+      
+      const newMarker = new markerClass({
+        position: {
+          lat: 180,
+          lng: 180
+        }
+      });
+
+      markerClusterer.addMarker(newMarker, false);
+
+      expect(MarkerUtils.setMap).toHaveBeenCalledTimes(2);
+    });
+
     test("markerClusterer addMarkers", () => {
       const markerClusterer = new MarkerClusterer({
         markers: [],

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -197,7 +197,7 @@ export class MarkerClusterer extends OverlayViewSafe {
             lat: cluster.position.lat(),
             lng: cluster.position.lng(),
           };
-          
+
           const duplicateCluster = records.get(clusterKey);
 
           if (duplicateCluster) {

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -180,12 +180,19 @@ export class MarkerClusterer extends OverlayViewSafe {
 
       // allow algorithms to return flag on whether the clusters/markers have changed
       if (changed || changed == undefined) {
+        const records = new Map<string, Cluster>();
+
+        this.clusters.forEach((cluster) =>
+          records.set(
+            `${cluster.position.lat()}x${cluster.position.lng()}`,
+            cluster
+          )
+        );
+
         clusters.forEach((cluster, index) => {
           // if there's clusters that has been "processed" (Cluster.marker is set), then reuse it instead of reprocessing it
-          const duplicateCluster = this.clusters.find(
-            (old) =>
-              old.marker &&
-              MarkerUtils.getPosition(old.marker).equals(cluster.position)
+          const duplicateCluster = records.get(
+            `${cluster.position.lat()}x${cluster.position.lng()}`
           );
 
           if (duplicateCluster) {

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -184,7 +184,7 @@ export class MarkerClusterer extends OverlayViewSafe {
 
           if(duplicate !== -1) {
             // we'll reset the Cluster.markers here and only add the existing item
-            // down below in renderClusters, it will assign this one item to Cluster.master
+            // down below in renderClusters, it will assign this one item to Cluster.marker
             clusters[index].markers.length = 0;
             clusters[index].markers.push(this.clusters[duplicate].marker);
 

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -180,23 +180,20 @@ export class MarkerClusterer extends OverlayViewSafe {
 
       // allow algorithms to return flag on whether the clusters/markers have changed
       if (changed || changed == undefined) {
-        const records = new Map<{ lat: number; lng: number }, Cluster>();
+        const records = new Map<string, Cluster>();
 
         this.clusters.forEach(
           (cluster) =>
             cluster.marker &&
             records.set(
-              { lat: cluster.position.lat(), lng: cluster.position.lng() },
+              `${cluster.position.lat()}x${cluster.position.lng()}`,
               cluster
             )
         );
 
         clusters.forEach((cluster, index) => {
           // if there's clusters that has been "processed" (Cluster.marker is set), then reuse it instead of reprocessing it
-          const clusterKey = {
-            lat: cluster.position.lat(),
-            lng: cluster.position.lng(),
-          };
+          const clusterKey = `${cluster.position.lat()}x${cluster.position.lng()}`;
 
           const duplicateCluster = records.get(clusterKey);
 

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -180,22 +180,23 @@ export class MarkerClusterer extends OverlayViewSafe {
 
       // allow algorithms to return flag on whether the clusters/markers have changed
       if (changed || changed == undefined) {
-        const records = new Map<string, Cluster>();
+        const records = new Map<{ lat: number; lng: number }, Cluster>();
 
         this.clusters.forEach(
           (cluster) =>
             cluster.marker &&
             records.set(
-              `${cluster.position.lat()}x${cluster.position.lng()}`,
+              { lat: cluster.position.lat(), lng: cluster.position.lng() },
               cluster
             )
         );
 
         clusters.forEach((cluster, index) => {
           // if there's clusters that has been "processed" (Cluster.marker is set), then reuse it instead of reprocessing it
-          const duplicateCluster = records.get(
-            `${cluster.position.lat()}x${cluster.position.lng()}`
-          );
+          const duplicateCluster = records.get({
+            lat: cluster.position.lat(),
+            lng: cluster.position.lng(),
+          });
 
           if (duplicateCluster) {
             // we'll reset the Cluster.markers here and only add the existing item

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -182,7 +182,7 @@ export class MarkerClusterer extends OverlayViewSafe {
       if (changed || changed == undefined) {
         clusters.forEach((cluster, index) => {
           // if there's clusters that has been "processed" (Cluster.marker is set), then reuse it instead of reprocessing it
-          const duplicate = this.clusters.findIndex((old) => old.marker && old.marker.getPosition().equals(cluster.position));
+          const duplicate = this.clusters.findIndex((old) => old.marker && MarkerUtils.getPosition(old.marker).equals(cluster.position));
 
           if(duplicate !== -1) {
             // we'll reset the Cluster.markers here and only add the existing item
@@ -239,7 +239,7 @@ export class MarkerClusterer extends OverlayViewSafe {
       } else {
         // we disable the markers here only when we're re-processing the cluster marker
         // this stops the markers from flickering on each map event.
-        cluster.markers.forEach((marker) => marker.setMap(null));
+        cluster.markers.forEach((marker) => MarkerUtils.setMap(marker, null));
         
         cluster.marker = this.renderer.render(cluster, stats, this.map);
 

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -182,15 +182,15 @@ export class MarkerClusterer extends OverlayViewSafe {
       if (changed || changed == undefined) {
         clusters.forEach((cluster, index) => {
           // if there's clusters that has been "processed" (Cluster.marker is set), then reuse it instead of reprocessing it
-          const duplicate = this.clusters.findIndex((old) => old.marker && MarkerUtils.getPosition(old.marker).equals(cluster.position));
+          const duplicateCluster = this.clusters.find((old) => old.marker && MarkerUtils.getPosition(old.marker).equals(cluster.position));
 
-          if(duplicate !== -1) {
+          if(duplicateCluster) {
             // we'll reset the Cluster.markers here and only add the existing item
             // down below in renderClusters, it will assign this one item to Cluster.marker
             clusters[index].markers.length = 0;
-            clusters[index].markers.push(this.clusters[duplicate].marker);
+            clusters[index].markers.push(duplicateCluster.marker);
 
-            this.clusters[duplicate].marker = null;
+            duplicateCluster.marker = null;
           }
         });
 

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -182,9 +182,13 @@ export class MarkerClusterer extends OverlayViewSafe {
       if (changed || changed == undefined) {
         clusters.forEach((cluster, index) => {
           // if there's clusters that has been "processed" (Cluster.marker is set), then reuse it instead of reprocessing it
-          const duplicateCluster = this.clusters.find((old) => old.marker && MarkerUtils.getPosition(old.marker).equals(cluster.position));
+          const duplicateCluster = this.clusters.find(
+            (old) =>
+              old.marker &&
+              MarkerUtils.getPosition(old.marker).equals(cluster.position)
+          );
 
-          if(duplicateCluster) {
+          if (duplicateCluster) {
             // we'll reset the Cluster.markers here and only add the existing item
             // down below in renderClusters, it will assign this one item to Cluster.marker
             clusters[index].markers.length = 0;
@@ -244,7 +248,7 @@ export class MarkerClusterer extends OverlayViewSafe {
         // we disable the markers here only when we're re-processing the cluster marker
         // this stops the markers from flickering on each map event.
         cluster.markers.forEach((marker) => MarkerUtils.setMap(marker, null));
-        
+
         cluster.marker = this.renderer.render(cluster, stats, map);
 
         if (this.onClusterClick) {

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -182,11 +182,13 @@ export class MarkerClusterer extends OverlayViewSafe {
       if (changed || changed == undefined) {
         const records = new Map<string, Cluster>();
 
-        this.clusters.forEach((cluster) =>
-          records.set(
-            `${cluster.position.lat()}x${cluster.position.lng()}`,
-            cluster
-          )
+        this.clusters.forEach(
+          (cluster) =>
+            cluster.marker &&
+            records.set(
+              `${cluster.position.lat()}x${cluster.position.lng()}`,
+              cluster
+            )
         );
 
         clusters.forEach((cluster, index) => {

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -195,7 +195,7 @@ export class MarkerClusterer extends OverlayViewSafe {
         });
 
         // reset visibility of markers and clusters
-        this.clusters.forEach((cluster) => cluster.delete());
+        this.resetClusters();
 
         // store new clusters
         this.clusters = clusters;
@@ -229,6 +229,10 @@ export class MarkerClusterer extends OverlayViewSafe {
     this.clusters = [];
   }
 
+  protected resetClusters(): void {
+    this.clusters.forEach((cluster) => cluster.delete());
+  }
+
   protected renderClusters(): void {
     // generate stats to pass to renderers
     const stats = new ClusterStats(this.markers, this.clusters);
@@ -241,7 +245,7 @@ export class MarkerClusterer extends OverlayViewSafe {
         // this stops the markers from flickering on each map event.
         cluster.markers.forEach((marker) => MarkerUtils.setMap(marker, null));
         
-        cluster.marker = this.renderer.render(cluster, stats, this.map);
+        cluster.marker = this.renderer.render(cluster, stats, map);
 
         if (this.onClusterClick) {
           cluster.marker.addListener(

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -193,10 +193,12 @@ export class MarkerClusterer extends OverlayViewSafe {
 
         clusters.forEach((cluster, index) => {
           // if there's clusters that has been "processed" (Cluster.marker is set), then reuse it instead of reprocessing it
-          const duplicateCluster = records.get({
+          const clusterKey = {
             lat: cluster.position.lat(),
             lng: cluster.position.lng(),
-          });
+          };
+          
+          const duplicateCluster = records.get(clusterKey);
 
           if (duplicateCluster) {
             // we'll reset the Cluster.markers here and only add the existing item
@@ -205,6 +207,7 @@ export class MarkerClusterer extends OverlayViewSafe {
             clusters[index].markers.push(duplicateCluster.marker);
 
             duplicateCluster.marker = null;
+            records.delete(clusterKey);
           }
         });
 

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -236,6 +236,8 @@ export class MarkerClusterer extends OverlayViewSafe {
       if (cluster.markers.length === 1) {
         cluster.marker = cluster.markers[0];
       } else {
+        // we disable the markers here only when we're re-processing the cluster marker
+        // this stops the markers from flickering on each map event.
         cluster.markers.forEach((marker) => marker.setMap(null));
         
         cluster.marker = this.renderer.render(cluster, stats);


### PR DESCRIPTION
This PR aims to resolve #439 by reusing the previous markers where possible, by comparing exact coordinates on clusters with a "processed" marker (Cluster.marker).

This also fixes part of #384. This will keep the bounce animation while zooming in and out, but it will stop when the marker is turned into a cluster and won't bounce when turned back into a marker again, [explained here](https://github.com/googlemaps/js-markerclusterer/issues/384#issuecomment-1210036844).

https://user-images.githubusercontent.com/78360666/213556345-4c9ac6b1-e6dc-452e-bd19-7ee5e3ae08db.mp4

This is how it was previously, taken from #439:

> [192104133-b37be700-7e72-44f8-898c-b9b8bb91f1cb.webm](https://user-images.githubusercontent.com/78360666/213556817-2e0e70e3-065e-4ccf-963f-a74e9c469895.webm)

