### PR TITLE
fix: added algorithmOptions to MarkerClusterer constructor

### DIFF
--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Algorithm, SuperClusterAlgorithm } from "./algorithms";
+import { Algorithm, AlgorithmOptions, SuperClusterAlgorithm } from "./algorithms";
 import { ClusterStats, DefaultRenderer, Renderer } from "./renderer";
 
 import { Cluster } from "./cluster";
@@ -33,6 +33,7 @@ export interface MarkerClustererOptions {
    * an array of {@link Cluster}.
    */
   algorithm?: Algorithm;
+  algorithmOptions?: AlgorithmOptions,
   map?: google.maps.Map | null;
   /**
    * An object that converts a {@link Cluster} into a `google.maps.Marker`.
@@ -71,13 +72,13 @@ export class MarkerClusterer extends OverlayViewSafe {
   protected renderer: Renderer;
   /** @see {@link MarkerClustererOptions.map} */
   protected map: google.maps.Map | null;
-  /** @see {@link MarkerClustererOptions.maxZoom} */
   protected idleListener: google.maps.MapsEventListener;
 
   constructor({
     map,
     markers = [],
-    algorithm = new SuperClusterAlgorithm({}),
+    algorithmOptions = {},
+    algorithm = new SuperClusterAlgorithm(algorithmOptions),
     renderer = new DefaultRenderer(),
     onClusterClick = defaultOnClusterClickHandler,
   }: MarkerClustererOptions) {


### PR DESCRIPTION
This resolves #374 by adding an AlgorithmOptions property to the MarkerClusterer constructor, removing the need to initialize the algorithm manually to set the common maxZoom property.

Feel free to deny this if you don't see it fit for the MarkerClusterer constructor. :)