### PR TITLE
Use the bounding box for all algorithms (including noop when below maxZoom)

### DIFF
--- a/src/algorithms/core.ts
+++ b/src/algorithms/core.ts
@@ -15,7 +15,6 @@
  */
 
 import { Cluster } from "../cluster";
-import { filterMarkersToPaddedViewport } from "./utils";
 
 export interface AlgorithmInput {
   /**
@@ -53,6 +52,9 @@ export interface Algorithm {
    * Calculates an array of {@link Cluster}.
    */
   calculate: ({ markers, map }: AlgorithmInput) => AlgorithmOutput;
+
+  /** Returns the current viewportPadding value. */
+  getViewportPadding: () => number;
 }
 
 export interface AlgorithmOptions {
@@ -89,6 +91,9 @@ export abstract class AbstractAlgorithm implements Algorithm {
    * and other optimizations can also be done here.
    */
   public abstract calculate({ markers, map }: AlgorithmInput): AlgorithmOutput;
+
+  /** Returns the current viewportPadding value. */
+  public abstract getViewportPadding(): number;
 
   /**
    * Clusters the markers and called from {@link calculate}.
@@ -138,16 +143,14 @@ export abstract class AbstractViewportAlgorithm extends AbstractAlgorithm {
 
     return {
       clusters: this.cluster({
-        markers: filterMarkersToPaddedViewport(
-          map,
-          mapCanvasProjection,
-          markers,
-          this.viewportPadding
-        ),
+        markers,
         map,
         mapCanvasProjection,
       }),
     };
+  }
+  public getViewportPadding(): number {
+    return this.viewportPadding;
   }
   protected abstract cluster({ markers, map }: AlgorithmInput): Cluster[];
 }

--- a/src/algorithms/grid.ts
+++ b/src/algorithms/grid.ts
@@ -20,11 +20,7 @@ import {
   AlgorithmOutput,
   ViewportAlgorithmOptions,
 } from "./core";
-import {
-  distanceBetweenPoints,
-  extendBoundsToPaddedViewport,
-  filterMarkersToPaddedViewport,
-} from "./utils";
+import { distanceBetweenPoints, extendBoundsToPaddedViewport } from "./utils";
 
 import { Cluster } from "../cluster";
 import equal from "fast-deep-equal";
@@ -85,12 +81,7 @@ export class GridAlgorithm extends AbstractViewportAlgorithm {
 
     return {
       clusters: this.cluster({
-        markers: filterMarkersToPaddedViewport(
-          map,
-          mapCanvasProjection,
-          markers,
-          this.viewportPadding
-        ),
+        markers,
         map,
         mapCanvasProjection,
       }),

--- a/src/algorithms/noop.ts
+++ b/src/algorithms/noop.ts
@@ -15,7 +15,7 @@
  */
 
 import {
-  AbstractAlgorithm,
+  AbstractViewportAlgorithm,
   AlgorithmInput,
   AlgorithmOptions,
   AlgorithmOutput,
@@ -26,7 +26,7 @@ import { Cluster } from "../cluster";
 /**
  * Noop algorithm does not generate any clusters or filter markers by the an extended viewport.
  */
-export class NoopAlgorithm extends AbstractAlgorithm {
+export class NoopAlgorithm extends AbstractViewportAlgorithm {
   constructor({ ...options }: AlgorithmOptions) {
     super(options);
   }

--- a/src/algorithms/supercluster.ts
+++ b/src/algorithms/supercluster.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { AbstractAlgorithm, AlgorithmInput, AlgorithmOutput } from "./core";
+import {
+  AbstractViewportAlgorithm,
+  AlgorithmInput,
+  AlgorithmOutput,
+} from "./core";
 import SuperCluster, { ClusterFeature } from "supercluster";
 
 import { Cluster } from "../cluster";
@@ -32,7 +36,7 @@ export type SuperClusterOptions = SuperCluster.Options<
  *
  * @see https://www.npmjs.com/package/supercluster for more information on options.
  */
-export class SuperClusterAlgorithm extends AbstractAlgorithm {
+export class SuperClusterAlgorithm extends AbstractViewportAlgorithm {
   protected superCluster: SuperCluster;
   protected markers: google.maps.Marker[];
   protected clusters: Cluster[];

--- a/src/markerclusterer.test.ts
+++ b/src/markerclusterer.test.ts
@@ -21,10 +21,11 @@ import {
   defaultOnClusterClickHandler,
 } from ".";
 
-import { initialize } from "@googlemaps/jest-mocks";
+import { initialize, MapCanvasProjection } from "@googlemaps/jest-mocks";
 
 const calculate = jest.fn().mockReturnValue({ clusters: [] });
-const algorithm = { calculate };
+const getViewportPadding = jest.fn().mockReturnValue(60);
+const algorithm = { calculate, getViewportPadding };
 
 const render = jest.fn().mockImplementation(() => new google.maps.Marker());
 const renderer = { render };
@@ -39,24 +40,27 @@ beforeEach(() => {
 
 afterEach(() => {
   calculate.mockClear();
+  getViewportPadding.mockClear();
   render.mockClear();
 });
 
 test("markerClusterer does not render if no map", () => {
   const calculate = jest.fn();
+  const getViewportPadding = jest.fn();
   const markerClusterer = new MarkerClusterer({
     markers: [],
-    algorithm: { calculate },
+    algorithm: { calculate, getViewportPadding },
   });
   markerClusterer.getMap = jest.fn().mockImplementation(() => null);
   markerClusterer.getProjection = jest.fn().mockImplementation(() => null);
 
   markerClusterer.render();
   expect(calculate).toHaveBeenCalledTimes(0);
+  expect(getViewportPadding).toHaveBeenCalledTimes(0);
 });
 
 test("markerClusterer calls calculate correctly", () => {
-  const mapCanvasProjection = jest.fn();
+  const mapCanvasProjection = new MapCanvasProjection();
   const markers: google.maps.Marker[] = [];
 
   const markerClusterer = new MarkerClusterer({
@@ -78,10 +82,11 @@ test("markerClusterer calls calculate correctly", () => {
 });
 
 test("markerClusterer does not reset and renderClusters if no change", () => {
-  const mapCanvasProjection = jest.fn();
+  const mapCanvasProjection = new MapCanvasProjection();
   const markers: google.maps.Marker[] = [];
   const algorithm = {
     calculate: jest.fn().mockReturnValue({ clusters: [], changed: false }),
+    getViewportPadding: jest.fn().mockReturnValue(60),
   };
   const markerClusterer = new MarkerClusterer({
     markers,

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -16,6 +16,7 @@
 
 import { Algorithm, SuperClusterAlgorithm } from "./algorithms";
 import { ClusterStats, DefaultRenderer, Renderer } from "./renderer";
+import { filterMarkersToPaddedViewport } from "./algorithms/utils";
 
 import { Cluster } from "./cluster";
 import { OverlayViewSafe } from "./overlay-view-safe";
@@ -170,10 +171,17 @@ export class MarkerClusterer extends OverlayViewSafe {
         MarkerClustererEvents.CLUSTERING_BEGIN,
         this
       );
+
+      const mapCanvasProjection = this.getProjection();
       const { clusters, changed } = this.algorithm.calculate({
-        markers: this.markers,
+        markers: filterMarkersToPaddedViewport(
+          map,
+          mapCanvasProjection,
+          this.markers,
+          this.algorithm.getViewportPadding()
+        ),
         map,
-        mapCanvasProjection: this.getProjection(),
+        mapCanvasProjection,
       });
 
       // allow algorithms to return flag on whether the clusters/markers have changed


### PR DESCRIPTION
I am seeing the same issue as @leighhalliday with respect to performance degradation with very large datasets when using the SuperCluster algorithm.  I also see similar issues when past the maxZoom level because the NoOp algorithm also ignores bounding boxes.  It appears that only the GridAlgorithm and the AbstractAlgorithm respect the bounding box while the SuperCluster and NoOp ones ignore it.

I believe that the most straightforward solution is to use the existing `filterMarkersToPaddedViewport` algorithm prior to passing markers to the calculate method (instead of only for the GridAlgorithm and AbtractAlgorithm each doing it individually.

This is what I implemented in this PR.

Fixes #136, #417, #419