### PR TITLE
fix: remove unnecessary logging when clusters are rendered

### DIFF
--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -172,11 +172,6 @@ export class MarkerClusterer extends OverlayViewSafe {
         MarkerClustererEvents.CLUSTERING_BEGIN,
         this
       );
-      this.markers.forEach((marker) => {
-        marker.addListener("animation_changed", () => {
-          console.log("animation_changed");
-        });
-      });
       const { clusters, changed } = this.algorithm.calculate({
         markers: this.markers,
         map,


### PR DESCRIPTION
Fixes #622 