### PR TITLE
Update supercluster.ts

### DIFF
--- a/src/algorithms/supercluster.ts
+++ b/src/algorithms/supercluster.ts
@@ -15,7 +15,7 @@
  */
 
 import { AbstractAlgorithm, AlgorithmInput, AlgorithmOutput } from "./core";
-import SuperCluster, { ClusterFeature } from "supercluster";
+import * as SuperCluster, { ClusterFeature } from "supercluster";
 import { MarkerUtils, Marker } from "../marker-utils";
 import { Cluster } from "../cluster";
 import equal from "fast-deep-equal";


### PR DESCRIPTION
Avoid Synthetic Default Imports

_To be tested_

I got the same issue again while migrating to the v2.1.4  
Fixes https://github.com/googlemaps/js-markerclusterer/issues/557
