### PR TITLE
fix: enable advanced markers in the examples

### DIFF
--- a/examples/algorithms.ts
+++ b/examples/algorithms.ts
@@ -21,14 +21,15 @@ import {
   NoopAlgorithm,
   SuperClusterAlgorithm,
 } from "../src";
-import { getLoaderOptions, sync } from "./config";
+import { MAP_ID, getLoaderOptions, sync } from "./config";
 
 import { Loader } from "@googlemaps/js-api-loader";
 import trees from "./trees.json";
 
-const mapOptions = {
+const mapOptions: google.maps.MapOptions = {
   center: { lat: 40.7128, lng: -73.85 },
   zoom: 10,
+  mapId: MAP_ID,
 };
 
 new Loader(getLoaderOptions()).load().then(() => {

--- a/examples/config.ts
+++ b/examples/config.ts
@@ -16,14 +16,14 @@
 
 import { LoaderOptions } from "@googlemaps/js-api-loader";
 
-export const MAP_ID = "7b9a897acd0a63a4";
+export const MAP_ID = "DEMO_MAP_ID";
 
 const DEFAULT_KEY = "AIzaSyDhRjl83cPVWeaEer-SnKIw7GTjBuqWxXI";
 
 export const getLoaderOptions = (): LoaderOptions => ({
   apiKey: localStorage.getItem("gmaps-key") ?? DEFAULT_KEY,
   version: "weekly",
-  libraries: [],
+  libraries: ["marker"],
 });
 
 // helper function to keep maps in sync

--- a/examples/defaults.ts
+++ b/examples/defaults.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-import { getLoaderOptions } from "./config";
+import { MAP_ID, getLoaderOptions } from "./config";
 import { Loader } from "@googlemaps/js-api-loader";
 import { MarkerClusterer } from "../src";
 import trees from "./trees.json";
 
-const mapOptions = {
+const mapOptions: google.maps.MapOptions = {
   center: { lat: 40.7128, lng: -73.85 },
   zoom: 12,
+  mapId: MAP_ID,
 };
 
 new Loader(getLoaderOptions()).load().then(() => {

--- a/examples/renderers.ts
+++ b/examples/renderers.ts
@@ -21,15 +21,16 @@ import {
   MarkerClusterer,
   Renderer,
 } from "../src";
-import { getLoaderOptions, sync } from "./config";
+import { MAP_ID, getLoaderOptions, sync } from "./config";
 
 import { Loader } from "@googlemaps/js-api-loader";
 import { interpolateRgb } from "d3-interpolate";
 import trees from "./trees.json";
 
-const mapOptions = {
+const mapOptions: google.maps.MapOptions = {
   center: { lat: 40.7128, lng: -73.85 },
   zoom: 10,
+  mapId: MAP_ID,
 };
 
 const interpolatedRenderer = {

--- a/examples/updates.ts
+++ b/examples/updates.ts
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
-import { getLoaderOptions } from "./config";
+import { MAP_ID, getLoaderOptions } from "./config";
 import { Loader } from "@googlemaps/js-api-loader";
 import { MarkerClusterer } from "../src";
 import trees from "./trees.json";
 
-const mapOptions = {
+const mapOptions: google.maps.MapOptions = {
   center: { lat: 40.7128, lng: -73.85 },
   zoom: 12,
+  mapId: MAP_ID,
 };
 
 new Loader(getLoaderOptions()).load().then(async () => {


### PR DESCRIPTION
There were a couple issues:
- The `marker` library was not loaded,
- There was no `mapId` passed when creating the map,

I also switched to the demo map id.
