### PR TITLE
fix: avoid direct assignment of innerHTML for Advanced Marker-based c…

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -127,9 +127,11 @@ export class DefaultRenderer implements Renderer {
 
     if (MarkerUtils.isAdvancedMarkerAvailable(map)) {
       // create cluster SVG element
-      const div = document.createElement("div");
-      div.innerHTML = svg;
-      const svgEl = div.firstElementChild;
+      const parser = new DOMParser();
+      const svgEl = parser.parseFromString(
+        svg,
+        "image/svg+xml"
+      ).documentElement;
       svgEl.setAttribute("transform", "translate(0 25)");
 
       const clusterOptions: google.maps.marker.AdvancedMarkerElementOptions = {


### PR DESCRIPTION
Fixes issue #729 as per the recommended remedies [here](https://github.com/googlemaps/js-markerclusterer/issues/729#issue-1850741843).