### PR TITLE
fix: handle zero as a valid value for marker position

### DIFF
--- a/src/marker-utils.ts
+++ b/src/marker-utils.ts
@@ -58,7 +58,7 @@ export class MarkerUtils {
           return marker.position;
         }
         // since we can't cast to LatLngLiteral for reasons =(
-        if (marker.position.lat && marker.position.lng) {
+        if (marker.position.lat != null && marker.position.lng != null) {
           return new google.maps.LatLng(
             marker.position.lat,
             marker.position.lng


### PR DESCRIPTION
Use null check to prevent 0 value to be falsy. 

Also, the code `new google.maps.LatLng(null);` return a marker with the coordiate (NaN, 0) and it break the SuperCluster algorithm. 

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #891 🦕
