### PR TITLE
fix: ensure marker position has valid numeric coordinates.

### DIFF
--- a/src/marker-utils.ts
+++ b/src/marker-utils.ts
@@ -58,7 +58,10 @@ export class MarkerUtils {
           return marker.position;
         }
         // since we can't cast to LatLngLiteral for reasons =(
-        if (marker.position.lat && marker.position.lng) {
+        if (
+          Number.isFinite(marker.position.lat) &&
+          Number.isFinite(marker.position.lng)
+        ) {
           return new google.maps.LatLng(
             marker.position.lat,
             marker.position.lng


### PR DESCRIPTION
Updated the condition to check if `lat` and `lng` are finite numbers before creating a `LatLng` object. This prevents potential runtime errors when lat and lng are 0.

Replaces: #892 and #927
Fixes: #891
