### PR TITLE
fix: prevent gmp-click warnings when using AdvancedMarkerElement

### DIFF
--- a/src/markerclusterer.test.ts
+++ b/src/markerclusterer.test.ts
@@ -253,7 +253,11 @@ describe.each(markerClasses)(
       clusters.forEach((cluster) => {
         expect(MarkerUtils.setMap).toBeCalledWith(cluster.marker, map);
         expect(cluster.marker?.addListener).toHaveBeenCalledWith(
-          "click",
+          /**
+           * - Standard `google.maps.Marker` uses the `"click"` event.
+             - `AdvancedMarkerElement` requires `"gmp-click"` instead.
+           */
+          MarkerUtils.isAdvancedMarker(cluster.marker!) ? "gmp-click" : "click",
           expect.any(Function)
         );
       });

--- a/src/markerclusterer.test.ts
+++ b/src/markerclusterer.test.ts
@@ -253,10 +253,7 @@ describe.each(markerClasses)(
       clusters.forEach((cluster) => {
         expect(MarkerUtils.setMap).toBeCalledWith(cluster.marker, map);
         expect(cluster.marker?.addListener).toHaveBeenCalledWith(
-          /**
-           * - Standard `google.maps.Marker` uses the `"click"` event.
-             - `AdvancedMarkerElement` requires `"gmp-click"` instead.
-           */
+          // legacy Marker uses 'click' events, whereas AdvancedMarkerElement uses 'gmp-click'
           MarkerUtils.isAdvancedMarker(cluster.marker!) ? "gmp-click" : "click",
           expect.any(Function)
         );

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -52,6 +52,7 @@ export enum MarkerClustererEvents {
   CLUSTERING_BEGIN = "clusteringbegin",
   CLUSTERING_END = "clusteringend",
   CLUSTER_CLICK = "click",
+  GMP_CLICK = "gmp-click",
 }
 
 export const defaultOnClusterClickHandler: onClusterClickHandler = (
@@ -259,8 +260,20 @@ export class MarkerClusterer extends OverlayViewSafe {
         // Make sure all individual markers are removed from the map.
         cluster.markers.forEach((marker) => MarkerUtils.setMap(marker, null));
         if (this.onClusterClick) {
+          /**
+           * As of February 21, 2024, `google.maps.Marker` is deprecated in favor of
+           * `google.maps.marker.AdvancedMarkerElement`. When handling click events:
+           * - Standard `google.maps.Marker` uses the `"click"` event.
+           * - `AdvancedMarkerElement` requires `"gmp-click"` instead.
+           */
+          const markerClickEventName = MarkerUtils.isAdvancedMarker(
+            cluster.marker
+          )
+            ? MarkerClustererEvents.GMP_CLICK
+            : MarkerClustererEvents.CLUSTER_CLICK;
+
           cluster.marker.addListener(
-            "click",
+            markerClickEventName,
             /* istanbul ignore next */
             (event: google.maps.MapMouseEvent) => {
               google.maps.event.trigger(

--- a/src/markerclusterer.ts
+++ b/src/markerclusterer.ts
@@ -260,12 +260,7 @@ export class MarkerClusterer extends OverlayViewSafe {
         // Make sure all individual markers are removed from the map.
         cluster.markers.forEach((marker) => MarkerUtils.setMap(marker, null));
         if (this.onClusterClick) {
-          /**
-           * As of February 21, 2024, `google.maps.Marker` is deprecated in favor of
-           * `google.maps.marker.AdvancedMarkerElement`. When handling click events:
-           * - Standard `google.maps.Marker` uses the `"click"` event.
-           * - `AdvancedMarkerElement` requires `"gmp-click"` instead.
-           */
+          // legacy Marker uses 'click' events, whereas AdvancedMarkerElement uses 'gmp-click'
           const markerClickEventName = MarkerUtils.isAdvancedMarker(
             cluster.marker
           )


### PR DESCRIPTION
As of February 21, 2024, `google.maps.Marker` is deprecated in favor of `google.maps.marker.AdvancedMarkerElement`. When handling click events:
- Standard `google.maps.Marker` uses the `"click"` event.
- The newer `google.maps.marker.AdvancedMarkerElement` requires `"gmp-click"` instead.

This fixes the warning: `Please use addEventListener('gmp-click', ...) instead of addEventListener('click', ...).` which occurs when advanced markers are used.

Thank you for opening a Pull Request!

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #611 🦕
