### PR TITLE
chore: add @rollup/plugin-replace for environment variable injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@rollup/plugin-html": "^2.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^16.0.0",
+        "@rollup/plugin-replace": "^6.0.3",
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-typescript": "^12.1.2",
         "@types/d3-interpolate": "^3.0.1",
@@ -3023,6 +3024,28 @@
       },
       "peerDependencies": {
         "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+      "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
       },
       "peerDependenciesMeta": {
         "rollup": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@rollup/plugin-html": "^2.0.0",
     "@rollup/plugin-json": "^6.0.0",
     "@rollup/plugin-node-resolve": "^16.0.0",
+    "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-typescript": "^12.1.2",
     "@types/d3-interpolate": "^3.0.1",

--- a/rollup.config.examples.mjs
+++ b/rollup.config.examples.mjs
@@ -25,6 +25,7 @@ import { nodeResolve } from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
 import serve from "rollup-plugin-serve";
 import copy from "rollup-plugin-copy";
+import replace from "@rollup/plugin-replace";
 
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url));
 
@@ -43,6 +44,10 @@ const getTemplate = (name) => {
 export default examples.map((name, index) => ({
   input: `examples/${name}.ts`,
   plugins: [
+    replace({
+      "process.env.NODE_ENV": JSON.stringify("production"),
+      preventAssignment: true,
+    }),
     typescript({
       tsconfig: "./tsconfig.json",
       compilerOptions: {


### PR DESCRIPTION
Updating to @googlemaps/js-api-loader v2 broke the examples due to missing replacement of environment variables. This PR introduces the required replacement for `process.env.NODE_ENV`.