### PR TITLE
feat: expose SuperCluster properties on clusters

### DIFF
--- a/src/algorithms/supercluster.test.ts
+++ b/src/algorithms/supercluster.test.ts
@@ -99,6 +99,35 @@ describe.each(testMarkerTypes)(
       expect(cluster.markers[0]).toBe(marker);
     });
 
+    test("should expose aggregated properties on Cluster", () => {
+      const superCluster = new SuperClusterAlgorithm({});
+      const marker: Marker = new markerClass();
+      const clusterFeature = {
+        type: "Feature",
+        geometry: { coordinates: [0, 0], type: "Point" },
+        properties: {
+          marker,
+          cluster: true,
+          cluster_id: 100,
+          point_count: 2,
+          point_count_abbreviated: 2,
+          highRiskCount: 1,
+          totalRisk: 3,
+        },
+      } as unknown as ClusterFeature<{ marker: Marker }>;
+
+      jest
+        .spyOn(superCluster["superCluster"], "getLeaves")
+        .mockImplementation(() => [clusterFeature]);
+
+      const cluster = superCluster["transformCluster"](clusterFeature);
+
+      expect(cluster.properties).toMatchObject({
+        highRiskCount: 1,
+        totalRisk: 3,
+      });
+    });
+
     test("should not cluster if zoom didn't change", () => {
       const mapCanvasProjection =
         jest.fn() as unknown as google.maps.MapCanvasProjection;

--- a/src/algorithms/supercluster.ts
+++ b/src/algorithms/supercluster.ts
@@ -127,6 +127,7 @@ export class SuperClusterAlgorithm extends AbstractAlgorithm {
           .getLeaves(properties.cluster_id, Infinity)
           .map((leaf) => leaf.properties.marker),
         position: { lat, lng },
+        properties,
       });
     }
 

--- a/src/algorithms/superviewport.ts
+++ b/src/algorithms/superviewport.ts
@@ -132,6 +132,7 @@ export class SuperClusterViewportAlgorithm extends AbstractViewportAlgorithm {
           .getLeaves(properties.cluster_id, Infinity)
           .map((leaf) => leaf.properties.marker),
         position: { lat, lng },
+        properties,
       });
     }
 

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -16,18 +16,24 @@
 
 import { MarkerUtils, Marker } from "./marker-utils";
 
+export type ClusterProperties = Record<string, unknown>;
+
 export interface ClusterOptions {
   position?: google.maps.LatLng | google.maps.LatLngLiteral;
   markers?: Marker[];
+  /** Algorithm-specific properties associated with this cluster. */
+  properties?: ClusterProperties;
 }
 
 export class Cluster {
   public marker?: Marker;
   public readonly markers: Marker[] = [];
+  public readonly properties?: ClusterProperties;
   protected _position?: google.maps.LatLng;
 
-  constructor({ markers, position }: ClusterOptions) {
+  constructor({ markers, position, properties }: ClusterOptions) {
     if (markers) this.markers = markers;
+    this.properties = properties;
     if (position) {
       if (position instanceof google.maps.LatLng) {
         this._position = position;


### PR DESCRIPTION
## Summary

Expose SuperCluster aggregated properties on the resulting `Cluster` object so custom renderers can access values produced by SuperCluster `map` / `reduce` functions.

## Changes

- add an optional `properties` field to `Cluster`
- preserve SuperCluster feature properties when converting a SuperCluster result into a `Cluster`
- apply the same behavior to `SuperClusterViewportAlgorithm`
- add regression coverage confirming aggregated properties are available through `cluster.properties`

This keeps the existing renderer API unchanged while allowing custom renderers to consume algorithm-specific aggregate data without recomputing it from every marker.

Example:

```ts
const renderer = {
  render: (cluster, stats, map) => {
    const properties = cluster.properties;

    // Properties produced by SuperCluster map/reduce are now available here.
    console.log(properties);

    return new google.maps.Marker({
      position: cluster.position,
      label: String(cluster.count),
    });
  },
};